### PR TITLE
Fix: Issue with upload showcase

### DIFF
--- a/views/index/index.php
+++ b/views/index/index.php
@@ -51,7 +51,7 @@ use yii\helpers\Url;
             PanelRow::widget([
                 'items' => [
                     ['title' => Yii::t('DevtoolsModule.views_index_index', 'Client'), 'url' => Url::to(['/devtools/showcase/view', 'id' => 'client']), 'text' => Yii::t('DevtoolsModule.views_index_index', 'Learn how to use the ajax client module to submit forms or request other data.')],
-                    ['disabled' => true, 'title' => Yii::t('DevtoolsModule.views_index_index', 'Upload'), 'url' => Url::to(['/devtools/showcase/view', 'id' => 'upload']), 'text' => Yii::t('DevtoolsModule.views_index_index', 'Learn how to create custom ui components.')],
+                    ['disabled' => false, 'title' => Yii::t('DevtoolsModule.views_index_index', 'Upload'), 'url' => Url::to(['/devtools/showcase/view', 'id' => 'upload']), 'text' => Yii::t('DevtoolsModule.views_index_index', 'Learn how to create custom ui components.')],
                     ['disabled' => true, 'title' => Yii::t('DevtoolsModule.views_index_index', 'Actions'), 'url' => Url::to(['/devtools/showcase/view', 'id' => 'actions']), 'text' => Yii::t('DevtoolsModule.views_index_index', 'Learn how to use the Javascript action api.')]
                 ]
             ]);

--- a/views/showcase/tabs/simple_upload/try.php
+++ b/views/showcase/tabs/simple_upload/try.php
@@ -12,7 +12,7 @@
     
     <div id="demo-progress" style="display:none;margin-top:5px;"></div>
     
-    <?= \humhub\modules\file\widgets\UploadPreview::widget([
+    <?= \humhub\modules\file\widgets\FilePreview::widget([
         'id' => 'demo-preview',
         'options' => [
             'style' => 'margin:10px'


### PR DESCRIPTION
Replacing UploadPreview with FilePreview allows for the use of upload showcase.

![screenshot_1](https://user-images.githubusercontent.com/2011633/46589309-06d21280-ca5d-11e8-8fc1-91574cab1949.png)
![screenshot_2](https://user-images.githubusercontent.com/2011633/46589310-06d21280-ca5d-11e8-8f4e-9485e3ae2253.png)
![screenshot_3](https://user-images.githubusercontent.com/2011633/46589311-06d21280-ca5d-11e8-971a-f027585a6e4a.png)